### PR TITLE
feat(CalendarInput): add autocomplete prop

### DIFF
--- a/src/calendar-input/calendar-input.jsx
+++ b/src/calendar-input/calendar-input.jsx
@@ -83,6 +83,8 @@ class CalendarInput extends React.Component {
             'anchor', 'top-left', 'top-center', 'top-right', 'left-top', 'left-center', 'left-bottom', 'right-top',
             'right-center', 'right-bottom', 'bottom-left', 'bottom-center', 'bottom-right'
         ])),
+        /** Управление автозаполнением компонента */
+        autocomplete: Type.bool,
         /** Управление возможностью изменения значения компонента */
         disabled: Type.bool,
         /** Размер компонента */
@@ -308,6 +310,7 @@ class CalendarInput extends React.Component {
                             this.customCalendarTarget = customCalendarTarget;
                         } }
                         { ...commonProps }
+                        autocomplete={ this.props.autocomplete }
                         className={ cn('custom-control') }
                         disabledAttr={ this.isNativeInput() || this.isMobilePopup() }
                         focused={ this.state.isInputFocused || this.state.isCalendarFocused }

--- a/src/calendar-input/calendar-input.test.jsx
+++ b/src/calendar-input/calendar-input.test.jsx
@@ -333,6 +333,20 @@ describe('calendar-input', () => {
         expect(onKeyDown).toHaveBeenCalledTimes(2);
     });
 
+    it('should render with `off` autocomplete attribute', () => {
+        let input = mount(<CalendarInput autocomplete={ false } />);
+        let controlNode = input.find('input');
+
+        expect(controlNode.props().autoComplete).toBe('off');
+    });
+
+    it('should render with `on` autocomplete attribute', () => {
+        let input = mount(<CalendarInput autocomplete={ true } />);
+        let controlNode = input.find('input');
+
+        expect(controlNode.props().autoComplete).toBe('on');
+    });
+
     describe('mobile', () => {
         beforeEach(() => {
             setMqMatched(true);


### PR DESCRIPTION
Прокидываем autocomplete в компонент Input внутри CalendarInput,
иначе попап с автокомплитом перекрывает календарь.
